### PR TITLE
Repair cluster type detection

### DIFF
--- a/VCF.JSONGenerator.psm1
+++ b/VCF.JSONGenerator.psm1
@@ -4394,7 +4394,7 @@ Function New-ClusterObject
         }
         $clusterObject | Add-Member -notepropertyname 'networkPoolCreationRequired' -notepropertyvalue $networkPoolCreationRequired
         
-        If ($clusterObject.rackinformation.multiRackResult -eq "Excluded")
+        If ($clusterObject.rackinformation.multiRackChosen -eq "N")
         {
             If ($clusterObject.vsphereClusters[0].vsanType -eq "vSAN HCI")
             {
@@ -4416,7 +4416,7 @@ Function New-ClusterObject
                 }                
             }
         }
-        elseIf ($clusterObject.rackinformation.multiRackResult -eq "Included")
+        elseIf ($clusterObject.rackinformation.multiRackChosen -eq "Y")
         {
             If ($clusterObject.vsphereClusters[0].vsanType -eq "vSAN HCI")
             {


### PR DESCRIPTION
Fix to repair regression in cluster object generation. Regression was causing empty determinedClusterConfig

Result of fix

<img width="1461" height="216" alt="image" src="https://github.com/user-attachments/assets/7a729e36-7ac9-4c44-8426-1dba72ba0829" />